### PR TITLE
Fix unsupported AppBar subtitle usage in ChatScreen

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -38,13 +38,26 @@ class _ChatScreenState extends State<ChatScreen> {
             ),
           );
         }
+        final String statusText = thread.isExpired
+            ? 'Chat expired'
+            : 'Participants: ${thread.participants.join(', ')}';
         return Scaffold(
           appBar: AppBar(
-            title: Text(thread.title),
-            subtitle: Text(
-              thread.isExpired
-                  ? 'Chat expired'
-                  : 'Participants: ${thread.participants.join(', ')}',
+            title: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(thread.title),
+                Text(
+                  statusText,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withOpacity(0.72),
+                      ),
+                ),
+              ],
             ),
           ),
           body: Column(


### PR DESCRIPTION
## Summary
- replace the unsupported AppBar subtitle in `ChatScreen` with a column-based title layout
- preserve the participant/status text beneath the title with themed styling

## Testing
- Not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7497486bc832186f081b4a975326f