### PR TITLE
Update chat input listener to refresh send button state

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -20,6 +20,14 @@ class _ChatScreenState extends State<ChatScreen> {
   final TextEditingController _controller = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
   void dispose() {
     _controller.dispose();
     super.dispose();
@@ -132,7 +140,9 @@ class _ChatScreenState extends State<ChatScreen> {
                                       sentAt: DateTime.now(),
                                     ),
                                   );
-                                  _controller.clear();
+                                  setState(() {
+                                    _controller.clear();
+                                  });
                                 },
                           child: const Icon(Icons.send),
                         ),


### PR DESCRIPTION
## Summary
- add an initState listener to rebuild the chat screen when the input text changes
- trigger a rebuild after clearing the message so the send button disables once empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7497aafe48321b2d7349fb9094ab5